### PR TITLE
Add Transwift USD/BDT static site (landing, auth, dashboard, orders, admin)

### DIFF
--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Dashboard | Transwift</title>
+  <meta name="description" content="Admin dashboard for Transwift exchange management." />
+  <link rel="icon" type="image/svg+xml" href="../assets/images/favicon.svg" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/admin.css" />
+  <script defer src="../js/main.js"></script>
+  <script defer src="../js/admin.js"></script>
+</head>
+<body>
+  <header class="admin-header">
+    <h1>Transwift Admin</h1>
+    <nav>
+      <a class="active" href="dashboard.html">Overview</a>
+      <a href="orders.html">Orders</a>
+      <a href="users.html">Users</a>
+      <a href="rates.html">Rates</a>
+      <button class="btn ghost" id="adminLogout">Logout</button>
+    </nav>
+  </header>
+
+  <main class="admin-dashboard">
+    <section class="stats-grid">
+      <article class="card">
+        <h3>Total Transactions</h3>
+        <p id="adminTotalTransactions">0</p>
+      </article>
+      <article class="card">
+        <h3>Total USD Volume</h3>
+        <p id="adminUsdVolume">$0.00</p>
+      </article>
+      <article class="card">
+        <h3>Total BDT Volume</h3>
+        <p id="adminBdtVolume">৳0.00</p>
+      </article>
+      <article class="card">
+        <h3>Pending Orders</h3>
+        <p id="adminPendingOrders">0</p>
+      </article>
+      <article class="card">
+        <h3>Total Users</h3>
+        <p id="adminUserCount">0</p>
+      </article>
+    </section>
+
+    <section class="card">
+      <h2>Latest Orders</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>User</th>
+            <th>Type</th>
+            <th>USD</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody id="adminLatestOrders"></tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/admin/login.html
+++ b/admin/login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Login | Transwift</title>
+  <meta name="description" content="Admin login for Transwift exchange management." />
+  <link rel="icon" type="image/svg+xml" href="../assets/images/favicon.svg" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/admin.css" />
+  <script defer src="../js/main.js"></script>
+  <script defer src="../js/admin.js"></script>
+</head>
+<body>
+  <main class="admin-login">
+    <section class="auth-card">
+      <h1>Admin Access</h1>
+      <p class="muted">Use admin credentials to manage Transwift.</p>
+      <form id="adminLoginForm">
+        <label>Email
+          <input type="email" id="adminEmail" required placeholder="admin@transwift.com" />
+        </label>
+        <label>Password
+          <input type="password" id="adminPassword" required placeholder="••••••••" />
+        </label>
+        <button class="btn primary" type="submit">Login</button>
+        <p class="helper">Return to <a href="../index.html">homepage</a></p>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/admin/orders.html
+++ b/admin/orders.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manage Orders | Transwift Admin</title>
+  <meta name="description" content="Review and approve Transwift USD/BDT orders." />
+  <link rel="icon" type="image/svg+xml" href="../assets/images/favicon.svg" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/admin.css" />
+  <script defer src="../js/main.js"></script>
+  <script defer src="../js/admin.js"></script>
+</head>
+<body>
+  <header class="admin-header">
+    <h1>Transwift Admin</h1>
+    <nav>
+      <a href="dashboard.html">Overview</a>
+      <a class="active" href="orders.html">Orders</a>
+      <a href="users.html">Users</a>
+      <a href="rates.html">Rates</a>
+      <button class="btn ghost" id="adminLogout">Logout</button>
+    </nav>
+  </header>
+
+  <main class="admin-dashboard">
+    <section class="card">
+      <h2>Manage Orders</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>User</th>
+            <th>Type</th>
+            <th>USD</th>
+            <th>BDT</th>
+            <th>Status</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody id="adminOrdersTable"></tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/admin/rates.html
+++ b/admin/rates.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rates | Transwift Admin</title>
+  <meta name="description" content="Manage USD/BDT exchange rates." />
+  <link rel="icon" type="image/svg+xml" href="../assets/images/favicon.svg" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/admin.css" />
+  <script defer src="../js/main.js"></script>
+  <script defer src="../js/admin.js"></script>
+</head>
+<body>
+  <header class="admin-header">
+    <h1>Transwift Admin</h1>
+    <nav>
+      <a href="dashboard.html">Overview</a>
+      <a href="orders.html">Orders</a>
+      <a href="users.html">Users</a>
+      <a class="active" href="rates.html">Rates</a>
+      <button class="btn ghost" id="adminLogout">Logout</button>
+    </nav>
+  </header>
+
+  <main class="admin-dashboard">
+    <section class="card">
+      <h2>Update Rates</h2>
+      <form id="rateForm" class="rate-form">
+        <label>Buy Rate (BDT/USD)
+          <input type="number" step="0.01" id="adminBuyRate" required />
+        </label>
+        <label>Sell Rate (BDT/USD)
+          <input type="number" step="0.01" id="adminSellRate" required />
+        </label>
+        <button class="btn primary" type="submit">Save Rates</button>
+        <p class="helper" id="rateStatus"></p>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/admin/rates.html
+++ b/admin/rates.html
@@ -25,13 +25,19 @@
 
   <main class="admin-dashboard">
     <section class="card">
-      <h2>Update Rates</h2>
+      <h2>Exchange Settings</h2>
       <form id="rateForm" class="rate-form">
         <label>Buy Rate (BDT/USD)
           <input type="number" step="0.01" id="adminBuyRate" required />
         </label>
         <label>Sell Rate (BDT/USD)
           <input type="number" step="0.01" id="adminSellRate" required />
+        </label>
+        <label>Minimum Order (USD)
+          <input type="number" step="0.01" id="adminMinOrder" required />
+        </label>
+        <label>Payment Gateways (comma separated)
+          <textarea id="adminGateways" rows="4" placeholder="Binance, Redotpay, Payoneer, bKash"></textarea>
         </label>
         <button class="btn primary" type="submit">Save Rates</button>
         <p class="helper" id="rateStatus"></p>

--- a/admin/users.html
+++ b/admin/users.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Users | Transwift Admin</title>
+  <meta name="description" content="View registered Transwift users." />
+  <link rel="icon" type="image/svg+xml" href="../assets/images/favicon.svg" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/admin.css" />
+  <script defer src="../js/main.js"></script>
+  <script defer src="../js/admin.js"></script>
+</head>
+<body>
+  <header class="admin-header">
+    <h1>Transwift Admin</h1>
+    <nav>
+      <a href="dashboard.html">Overview</a>
+      <a href="orders.html">Orders</a>
+      <a class="active" href="users.html">Users</a>
+      <a href="rates.html">Rates</a>
+      <button class="btn ghost" id="adminLogout">Logout</button>
+    </nav>
+  </header>
+
+  <main class="admin-dashboard">
+    <section class="card">
+      <h2>Registered Users</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Phone</th>
+            <th>Registered</th>
+          </tr>
+        </thead>
+        <tbody id="adminUsersTable"></tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#2563eb"/>
+  <path d="M20 20h24v6H20zm0 10h18v6H20zm0 10h24v6H20z" fill="#fff"/>
+</svg>

--- a/buy.html
+++ b/buy.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Buy USD | Transwift</title>
+  <meta name="description" content="Buy USD with BDT using Transwift's secure exchange." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/dashboard.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/rates.js"></script>
+  <script defer src="js/orders.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+      <div class="nav-links">
+        <a href="dashboard.html">Dashboard</a>
+        <a href="buy.html" class="active">Buy USD</a>
+        <a href="sell.html">Sell USD</a>
+        <a href="transactions.html">Transactions</a>
+        <button class="btn ghost" id="logoutBtn">Logout</button>
+      </div>
+    </nav>
+  </header>
+
+  <main class="order-page">
+    <section class="order-summary">
+      <h1>Buy USD</h1>
+      <p>Pay in BDT and receive USD instantly.</p>
+      <div class="card">
+        <p>Current Buy Rate: <strong id="buyRate">119.50</strong> BDT</p>
+        <p>Last updated: <span id="rateUpdated">--</span></p>
+      </div>
+    </section>
+
+    <section class="order-form card">
+      <h2>Place Buy Order</h2>
+      <form id="buyForm" data-type="Buy">
+        <label>USD Amount
+          <input type="number" id="usdAmount" placeholder="100" required />
+        </label>
+        <label>Payment Method
+          <select id="paymentMethod" required>
+            <option value="">Select method</option>
+            <option value="Bank Transfer">Bank Transfer</option>
+            <option value="bKash">bKash</option>
+            <option value="Nagad">Nagad</option>
+          </select>
+        </label>
+        <label>Account Details
+          <input type="text" id="accountDetails" placeholder="Account or wallet number" required />
+        </label>
+        <div class="order-result" id="orderSummary"></div>
+        <button class="btn primary" type="submit">Confirm Buy</button>
+      </form>
+    </section>
+  </main>
+
+  <div class="modal" id="orderModal" aria-hidden="true">
+    <div class="modal-content">
+      <h3>Order Confirmed</h3>
+      <p id="modalMessage"></p>
+      <button class="btn primary" id="closeModal">Done</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/buy.html
+++ b/buy.html
@@ -34,6 +34,7 @@
       <div class="card">
         <p>Current Buy Rate: <strong id="buyRate">119.50</strong> BDT</p>
         <p>Last updated: <span id="rateUpdated">--</span></p>
+        <p class="muted">Minimum order: $<span id="minOrder">--</span></p>
       </div>
     </section>
 
@@ -44,12 +45,7 @@
           <input type="number" id="usdAmount" placeholder="100" required />
         </label>
         <label>Payment Method
-          <select id="paymentMethod" required>
-            <option value="">Select method</option>
-            <option value="Bank Transfer">Bank Transfer</option>
-            <option value="bKash">bKash</option>
-            <option value="Nagad">Nagad</option>
-          </select>
+          <select id="paymentMethod" required></select>
         </label>
         <label>Account Details
           <input type="text" id="accountDetails" placeholder="Account or wallet number" required />

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact | Transwift</title>
+  <meta name="description" content="Contact Transwift support for USD/BDT exchange help." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/dashboard.css" />
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="buy.html">Buy USD</a>
+        <a href="sell.html">Sell USD</a>
+        <a href="contact.html" class="active">Contact</a>
+        <a href="login.html" class="btn secondary">Login</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="contact-page">
+    <section class="section-header">
+      <div>
+        <h1>Contact Transwift</h1>
+        <p>We respond within 24 hours to all inquiries.</p>
+      </div>
+    </section>
+
+    <section class="card contact-card">
+      <form id="contactForm">
+        <label>Name
+          <input type="text" id="contactName" required placeholder="Your name" />
+        </label>
+        <label>Email
+          <input type="email" id="contactEmail" required placeholder="you@email.com" />
+        </label>
+        <label>Subject
+          <input type="text" id="contactSubject" required placeholder="How can we help?" />
+        </label>
+        <label>Message
+          <textarea id="contactMessage" rows="5" required placeholder="Write your message"></textarea>
+        </label>
+        <button class="btn primary" type="submit">Send Message</button>
+        <p class="helper" id="contactSuccess"></p>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,0 +1,63 @@
+.admin-header {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 24px 8%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.admin-header nav {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.admin-header a {
+  color: #cbd5f5;
+  font-weight: 500;
+}
+
+.admin-header a.active {
+  color: #fff;
+}
+
+.admin-dashboard {
+  padding: 40px 8% 60px;
+  display: grid;
+  gap: 24px;
+}
+
+.admin-login {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 20px;
+}
+
+.rate-form {
+  display: grid;
+  gap: 16px;
+  max-width: 420px;
+}
+
+.action-btn {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.action-btn.approve {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--accent);
+}
+
+.action-btn.reject {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--error);
+}

--- a/css/auth.css
+++ b/css/auth.css
@@ -1,0 +1,33 @@
+.auth-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 80px 16px;
+}
+
+.auth-card {
+  background: var(--white);
+  padding: 32px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  width: min(420px, 100%);
+  display: grid;
+  gap: 16px;
+}
+
+.auth-card form {
+  display: grid;
+  gap: 14px;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+}
+
+.checkbox input {
+  width: 18px;
+  height: 18px;
+}

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,0 +1,74 @@
+.dashboard,
+.order-page,
+.transactions-page,
+.contact-page {
+  padding: 40px 8% 60px;
+  display: grid;
+  gap: 32px;
+}
+
+.dashboard-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.dashboard-card {
+  background: var(--white);
+  padding: 20px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  min-width: 240px;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.recent-orders table,
+.transactions-page table,
+.admin-dashboard table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+tr:nth-child(even) {
+  background: #f1f5f9;
+}
+
+.order-page {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.order-form form {
+  display: grid;
+  gap: 14px;
+}
+
+.order-result {
+  background: rgba(37, 99, 235, 0.08);
+  padding: 12px;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.contact-card form {
+  display: grid;
+  gap: 14px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,373 @@
+:root {
+  --primary: #2563eb;
+  --secondary: #1e40af;
+  --accent: #10b981;
+  --warning: #f59e0b;
+  --error: #ef4444;
+  --bg: #f8fafc;
+  --text: #1e293b;
+  --muted: #64748b;
+  --white: #ffffff;
+  --radius: 16px;
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.site-header {
+  background: var(--white);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+}
+
+.site-header.compact {
+  position: static;
+  box-shadow: none;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 8%;
+  gap: 16px;
+}
+
+.logo {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.nav-links {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.nav-links a {
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.nav-links a.active {
+  color: var(--primary);
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: var(--white);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+}
+
+.btn.secondary {
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--primary);
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: var(--muted);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+  padding: 80px 8% 40px;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.3rem, 3vw, 3.4rem);
+  margin: 12px 0 16px;
+}
+
+.lead {
+  color: var(--muted);
+  max-width: 560px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: inline-flex;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.hero-card {
+  background: var(--white);
+  padding: 28px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.rate-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.rate-grid strong {
+  font-size: 1.6rem;
+}
+
+.rate-updated {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.trend {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.trend-indicator {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.trend-indicator.up {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--accent);
+}
+
+.trend-indicator.down {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--error);
+}
+
+.section {
+  padding: 40px 8% 20px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.section-header p {
+  color: var(--muted);
+}
+
+.card {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.calculator {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: end;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+input,
+select,
+textarea {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: #fff;
+  font-size: 1rem;
+}
+
+.features .feature-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.site-footer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+  padding: 40px 8%;
+  background: #0f172a;
+  color: #e2e8f0;
+  margin-top: 60px;
+}
+
+.site-footer a {
+  color: #cbd5f5;
+  display: block;
+  margin-top: 8px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.helper {
+  color: var(--muted);
+  margin-top: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge.pending {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
+}
+
+.badge.completed {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--accent);
+}
+
+.badge.cancelled {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--error);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.modal.active {
+  display: flex;
+}
+
+.modal-content {
+  background: var(--white);
+  padding: 24px;
+  border-radius: var(--radius);
+  max-width: 380px;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.toast {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  background: var(--primary);
+  color: var(--white);
+  padding: 12px 18px;
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  z-index: 20;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: all 0.3s ease;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 900px) {
+  .nav-links {
+    position: absolute;
+    top: 72px;
+    right: 8%;
+    background: var(--white);
+    flex-direction: column;
+    padding: 16px;
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+    display: none;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 700px) {
+  .hero {
+    padding: 60px 8% 20px;
+  }
+
+  .navbar {
+    padding: 18px 6%;
+  }
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>User Dashboard | Transwift</title>
+  <meta name="description" content="Transwift dashboard to manage USD/BDT exchanges, orders, and insights." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/dashboard.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/rates.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+      <div class="nav-links">
+        <a href="dashboard.html" class="active">Dashboard</a>
+        <a href="buy.html">Buy USD</a>
+        <a href="sell.html">Sell USD</a>
+        <a href="transactions.html">Transactions</a>
+        <button class="btn ghost" id="logoutBtn">Logout</button>
+      </div>
+    </nav>
+  </header>
+
+  <main class="dashboard">
+    <section class="dashboard-hero">
+      <div>
+        <h1>Hello, <span id="userName">Trader</span> 👋</h1>
+        <p>Keep track of your USD/BDT exchange activity and manage new orders.</p>
+      </div>
+      <div class="dashboard-card">
+        <h3>Live Rates</h3>
+        <p>Buy: <strong id="buyRate">119.50</strong> BDT</p>
+        <p>Sell: <strong id="sellRate">118.00</strong> BDT</p>
+        <p class="muted">Updated <span id="rateUpdated">--</span></p>
+      </div>
+    </section>
+
+    <section class="stats-grid">
+      <article class="card">
+        <h3>Total Orders</h3>
+        <p id="statOrders">0</p>
+      </article>
+      <article class="card">
+        <h3>Pending Orders</h3>
+        <p id="statPending">0</p>
+      </article>
+      <article class="card">
+        <h3>Total USD Volume</h3>
+        <p id="statUsd">$0.00</p>
+      </article>
+      <article class="card">
+        <h3>Total BDT Volume</h3>
+        <p id="statBdt">৳0.00</p>
+      </article>
+    </section>
+
+    <section class="recent-orders">
+      <div class="section-header">
+        <h2>Recent Orders</h2>
+        <a class="btn secondary" href="transactions.html">View all</a>
+      </div>
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Type</th>
+              <th>USD</th>
+              <th>BDT</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody id="recentOrders"></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const user = JSON.parse(localStorage.getItem('tw_active_user') || '{}');
+      if (user.name) {
+        document.getElementById('userName').textContent = user.name;
+      }
+      const orders = JSON.parse(localStorage.getItem('tw_transactions') || '[]');
+      const stats = {
+        total: orders.length,
+        pending: orders.filter((o) => o.status === 'Pending').length,
+        usd: orders.reduce((sum, o) => sum + Number(o.usdAmount || 0), 0),
+        bdt: orders.reduce((sum, o) => sum + Number(o.bdtAmount || 0), 0),
+      };
+      document.getElementById('statOrders').textContent = stats.total;
+      document.getElementById('statPending').textContent = stats.pending;
+      document.getElementById('statUsd').textContent = `$${stats.usd.toFixed(2)}`;
+      document.getElementById('statBdt').textContent = `৳${stats.bdt.toFixed(2)}`;
+
+      const recent = orders.slice(-4).reverse();
+      const tbody = document.getElementById('recentOrders');
+      tbody.innerHTML = recent
+        .map(
+          (o) => `
+            <tr>
+              <td>${o.date}</td>
+              <td>${o.type}</td>
+              <td>${Number(o.usdAmount).toFixed(2)}</td>
+              <td>${Number(o.bdtAmount).toFixed(2)}</td>
+              <td><span class="badge ${o.status.toLowerCase()}">${o.status}</span></td>
+            </tr>
+          `
+        )
+        .join('');
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Transwift | USD to BDT Exchange</title>
+  <meta name="description" content="Transwift helps you exchange USD to BDT instantly with transparent buy/sell rates, secure orders, and real-time tracking." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/rates.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+      <div class="nav-links">
+        <a href="index.html" class="active">Home</a>
+        <a href="buy.html">Buy USD</a>
+        <a href="sell.html">Sell USD</a>
+        <a href="transactions.html">Transactions</a>
+        <a href="contact.html">Contact</a>
+        <a href="login.html" class="btn secondary">Login</a>
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="hero-content">
+        <p class="pill">USD ↔ BDT Exchange</p>
+        <h1>Move money fast with transparent USD/BDT rates.</h1>
+        <p class="lead">Transwift gives you real-time rates, instant order placement, and a secure dashboard to manage every exchange.</p>
+        <div class="hero-actions">
+          <a class="btn primary" href="register.html">Get Started</a>
+          <a class="btn ghost" href="dashboard.html">View Dashboard</a>
+        </div>
+      </div>
+      <div class="hero-card">
+        <h3>Live Rates</h3>
+        <div class="rate-grid">
+          <div>
+            <span>Buy USD</span>
+            <strong id="buyRate">119.50</strong>
+          </div>
+          <div>
+            <span>Sell USD</span>
+            <strong id="sellRate">118.00</strong>
+          </div>
+        </div>
+        <p class="rate-updated">Last updated: <span id="rateUpdated">--</span></p>
+        <div class="trend">
+          <span id="buyTrend" class="trend-indicator up">▲ 0.25%</span>
+          <span id="sellTrend" class="trend-indicator down">▼ 0.10%</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-header">
+        <h2>Calculate your exchange</h2>
+        <p>Convert USD to BDT or BDT to USD instantly with live rates.</p>
+      </div>
+      <div class="calculator card">
+        <div>
+          <label for="calcAmount">Amount</label>
+          <input type="number" id="calcAmount" placeholder="Enter amount" />
+        </div>
+        <div>
+          <label for="calcDirection">Direction</label>
+          <select id="calcDirection">
+            <option value="usdToBdt">USD → BDT</option>
+            <option value="bdtToUsd">BDT → USD</option>
+          </select>
+        </div>
+        <div>
+          <label for="calcResult">Result</label>
+          <input type="text" id="calcResult" readonly />
+        </div>
+        <button class="btn primary" id="calcBtn">Calculate</button>
+      </div>
+    </section>
+
+    <section class="section features">
+      <div class="section-header">
+        <h2>Why Transwift?</h2>
+        <p>Modern tools built for fast, transparent currency exchange.</p>
+      </div>
+      <div class="feature-grid">
+        <article class="card">
+          <h3>Instant Orders</h3>
+          <p>Place buy/sell requests with automated summaries and transparent fees.</p>
+        </article>
+        <article class="card">
+          <h3>Secure Dashboard</h3>
+          <p>Track balances, orders, and transaction history from one hub.</p>
+        </article>
+        <article class="card">
+          <h3>Admin Oversight</h3>
+          <p>Admins can manage users, rates, and approvals in real time.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div>
+      <h4>Transwift</h4>
+      <p>Smart USD/BDT exchange for individuals and businesses.</p>
+    </div>
+    <div>
+      <h5>Quick Links</h5>
+      <a href="buy.html">Buy USD</a>
+      <a href="sell.html">Sell USD</a>
+      <a href="contact.html">Contact</a>
+    </div>
+    <div>
+      <h5>Support</h5>
+      <p>Email: support@transwift.com</p>
+      <p>Phone: +880 1234 567 890</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -132,21 +132,36 @@ const populateAdminUsers = () => {
 const setupRateForm = () => {
   const form = document.getElementById('rateForm');
   if (!form) return;
-  const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+  const rates = TranswiftStore.get('tw_rates', {
+    buyRate: 119.5,
+    sellRate: 118.0,
+    minOrderUsd: 50,
+    gateways: ['Binance', 'Redotpay', 'Payoneer', 'bKash', 'Nagad'],
+  });
   document.getElementById('adminBuyRate').value = rates.buyRate;
   document.getElementById('adminSellRate').value = rates.sellRate;
+  document.getElementById('adminMinOrder').value = rates.minOrderUsd ?? 50;
+  document.getElementById('adminGateways').value = (rates.gateways || []).join(', ');
 
   form.addEventListener('submit', (event) => {
     event.preventDefault();
     const buyRate = Number(document.getElementById('adminBuyRate').value);
     const sellRate = Number(document.getElementById('adminSellRate').value);
-    if (!buyRate || !sellRate) {
+    const minOrderUsd = Number(document.getElementById('adminMinOrder').value);
+    const gatewaysRaw = document.getElementById('adminGateways').value;
+    const gateways = gatewaysRaw
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+    if (!buyRate || !sellRate || !minOrderUsd) {
       TranswiftUI.toast('Please enter valid rates.', 'error');
       return;
     }
     TranswiftStore.set('tw_rates', {
       buyRate,
       sellRate,
+      minOrderUsd,
+      gateways: gateways.length ? gateways : ['Binance', 'Redotpay', 'Payoneer', 'bKash', 'Nagad'],
       updatedAt: new Date().toLocaleString(),
       buyTrend: 0.12,
       sellTrend: -0.05,

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,168 @@
+const adminLoginForm = document.getElementById('adminLoginForm');
+const adminLogout = document.getElementById('adminLogout');
+
+const ensureAdminAuth = () => {
+  const isLoginPage = window.location.pathname.includes('admin/login.html');
+  const authed = localStorage.getItem('tw_admin_auth') === 'true';
+  if (!isLoginPage && !authed) {
+    window.location.href = 'login.html';
+  }
+};
+
+const adminLogin = () => {
+  if (!adminLoginForm) return;
+  adminLoginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const email = document.getElementById('adminEmail').value.trim();
+    const password = document.getElementById('adminPassword').value;
+    const admin = TranswiftStore.get('tw_admin', { email: '', password: '' });
+
+    if (email === admin.email && password === admin.password) {
+      localStorage.setItem('tw_admin_auth', 'true');
+      TranswiftUI.toast('Welcome, Admin!');
+      window.location.href = 'dashboard.html';
+    } else {
+      TranswiftUI.toast('Invalid admin credentials.', 'error');
+    }
+  });
+};
+
+const setupAdminLogout = () => {
+  if (!adminLogout) return;
+  adminLogout.addEventListener('click', () => {
+    localStorage.removeItem('tw_admin_auth');
+    TranswiftUI.toast('Logged out from admin.');
+    window.location.href = 'login.html';
+  });
+};
+
+const populateAdminDashboard = () => {
+  const totalEl = document.getElementById('adminTotalTransactions');
+  if (!totalEl) return;
+  const transactions = TranswiftStore.get('tw_transactions', []);
+  const users = TranswiftStore.get('tw_users', []);
+
+  const totalUsd = transactions.reduce((sum, tx) => sum + Number(tx.usdAmount || 0), 0);
+  const totalBdt = transactions.reduce((sum, tx) => sum + Number(tx.bdtAmount || 0), 0);
+  const pending = transactions.filter((tx) => tx.status === 'Pending').length;
+
+  document.getElementById('adminTotalTransactions').textContent = transactions.length;
+  document.getElementById('adminUsdVolume').textContent = `$${totalUsd.toFixed(2)}`;
+  document.getElementById('adminBdtVolume').textContent = `৳${totalBdt.toFixed(2)}`;
+  document.getElementById('adminPendingOrders').textContent = pending;
+  document.getElementById('adminUserCount').textContent = users.length;
+
+  const latestOrders = document.getElementById('adminLatestOrders');
+  if (latestOrders) {
+    latestOrders.innerHTML = transactions
+      .slice(-5)
+      .reverse()
+      .map(
+        (tx) => `
+          <tr>
+            <td>${tx.date}</td>
+            <td>${tx.userEmail}</td>
+            <td>${tx.type}</td>
+            <td>${Number(tx.usdAmount).toFixed(2)}</td>
+            <td><span class="badge ${tx.status.toLowerCase()}">${tx.status}</span></td>
+          </tr>
+        `
+      )
+      .join('');
+  }
+};
+
+const populateAdminOrders = () => {
+  const ordersTable = document.getElementById('adminOrdersTable');
+  if (!ordersTable) return;
+  const transactions = TranswiftStore.get('tw_transactions', []);
+
+  ordersTable.innerHTML = transactions
+    .map(
+      (tx, index) => `
+        <tr>
+          <td>${tx.date}</td>
+          <td>${tx.userEmail}</td>
+          <td>${tx.type}</td>
+          <td>${Number(tx.usdAmount).toFixed(2)}</td>
+          <td>${Number(tx.bdtAmount).toFixed(2)}</td>
+          <td><span class="badge ${tx.status.toLowerCase()}">${tx.status}</span></td>
+          <td>
+            <button class="action-btn approve" data-index="${index}" data-action="Completed">Approve</button>
+            <button class="action-btn reject" data-index="${index}" data-action="Cancelled">Reject</button>
+          </td>
+        </tr>
+      `
+    )
+    .join('');
+
+  ordersTable.querySelectorAll('button').forEach((button) => {
+    button.addEventListener('click', () => {
+      const idx = Number(button.dataset.index);
+      const action = button.dataset.action;
+      const updated = TranswiftStore.get('tw_transactions', []);
+      if (updated[idx]) {
+        updated[idx].status = action;
+        TranswiftStore.set('tw_transactions', updated);
+        populateAdminOrders();
+        TranswiftUI.toast(`Order ${action.toLowerCase()} successfully.`);
+      }
+    });
+  });
+};
+
+const populateAdminUsers = () => {
+  const usersTable = document.getElementById('adminUsersTable');
+  if (!usersTable) return;
+  const users = TranswiftStore.get('tw_users', []);
+  usersTable.innerHTML = users
+    .map(
+      (user) => `
+        <tr>
+          <td>${user.name}</td>
+          <td>${user.email}</td>
+          <td>${user.phone}</td>
+          <td>${user.createdAt || '-'}</td>
+        </tr>
+      `
+    )
+    .join('');
+};
+
+const setupRateForm = () => {
+  const form = document.getElementById('rateForm');
+  if (!form) return;
+  const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+  document.getElementById('adminBuyRate').value = rates.buyRate;
+  document.getElementById('adminSellRate').value = rates.sellRate;
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const buyRate = Number(document.getElementById('adminBuyRate').value);
+    const sellRate = Number(document.getElementById('adminSellRate').value);
+    if (!buyRate || !sellRate) {
+      TranswiftUI.toast('Please enter valid rates.', 'error');
+      return;
+    }
+    TranswiftStore.set('tw_rates', {
+      buyRate,
+      sellRate,
+      updatedAt: new Date().toLocaleString(),
+      buyTrend: 0.12,
+      sellTrend: -0.05,
+    });
+    const status = document.getElementById('rateStatus');
+    if (status) {
+      status.textContent = 'Rates updated successfully.';
+    }
+    TranswiftUI.toast('Rates updated!');
+  });
+};
+
+ensureAdminAuth();
+adminLogin();
+setupAdminLogout();
+populateAdminDashboard();
+populateAdminOrders();
+populateAdminUsers();
+setupRateForm();

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,72 @@
+const registerForm = document.getElementById('registerForm');
+const loginForm = document.getElementById('loginForm');
+
+if (registerForm) {
+  registerForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const name = document.getElementById('regName').value.trim();
+    const email = document.getElementById('regEmail').value.trim();
+    const phone = document.getElementById('regPhone').value.trim();
+    const password = document.getElementById('regPassword').value;
+    const confirm = document.getElementById('regConfirm').value;
+
+    if (!name || !email || !phone || !password || !confirm) {
+      TranswiftUI.toast('Please complete all fields.', 'error');
+      return;
+    }
+
+    if (password !== confirm) {
+      TranswiftUI.toast('Passwords do not match.', 'error');
+      return;
+    }
+
+    const users = TranswiftStore.get('tw_users', []);
+    if (users.find((user) => user.email === email)) {
+      TranswiftUI.toast('Account already exists. Please login.', 'error');
+      return;
+    }
+
+    users.push({
+      name,
+      email,
+      phone,
+      password,
+      createdAt: new Date().toLocaleDateString(),
+    });
+    TranswiftStore.set('tw_users', users);
+    TranswiftUI.toast('Registration successful!');
+    window.location.href = 'login.html';
+  });
+}
+
+if (loginForm) {
+  const remembered = localStorage.getItem('tw_remember_email');
+  if (remembered) {
+    document.getElementById('loginEmail').value = remembered;
+    document.getElementById('rememberMe').checked = true;
+  }
+
+  loginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const email = document.getElementById('loginEmail').value.trim();
+    const password = document.getElementById('loginPassword').value;
+    const remember = document.getElementById('rememberMe').checked;
+
+    const users = TranswiftStore.get('tw_users', []);
+    const user = users.find((u) => u.email === email && u.password === password);
+
+    if (!user) {
+      TranswiftUI.toast('Invalid login credentials.', 'error');
+      return;
+    }
+
+    TranswiftStore.set('tw_active_user', user);
+    if (remember) {
+      localStorage.setItem('tw_remember_email', email);
+    } else {
+      localStorage.removeItem('tw_remember_email');
+    }
+    TranswiftUI.toast('Login successful!');
+    window.location.href = 'dashboard.html';
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -46,6 +46,8 @@ const seedDemoData = () => {
     TranswiftStore.set('tw_rates', {
       buyRate: 119.5,
       sellRate: 118.0,
+      minOrderUsd: 50,
+      gateways: ['Binance', 'Redotpay', 'Payoneer', 'bKash', 'Nagad'],
       updatedAt: new Date().toLocaleString(),
       buyTrend: 0.25,
       sellTrend: -0.1,

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,140 @@
+const TranswiftStore = {
+  get(key, fallback) {
+    const value = localStorage.getItem(key);
+    return value ? JSON.parse(value) : fallback;
+  },
+  set(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+};
+
+const TranswiftUI = {
+  toast(message, type = 'info') {
+    let toast = document.querySelector('.toast');
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.className = 'toast';
+      document.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.style.background = type === 'error' ? 'var(--error)' : 'var(--primary)';
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 2800);
+  },
+};
+
+const seedDemoData = () => {
+  const users = TranswiftStore.get('tw_users', []);
+  if (!users.find((u) => u.email === 'user@test.com')) {
+    users.push({
+      name: 'Demo User',
+      email: 'user@test.com',
+      phone: '+8801000000000',
+      password: 'user123',
+      createdAt: new Date().toLocaleDateString(),
+    });
+  }
+  TranswiftStore.set('tw_users', users);
+
+  const admin = TranswiftStore.get('tw_admin', null);
+  if (!admin) {
+    TranswiftStore.set('tw_admin', { email: 'admin@transwift.com', password: 'admin123' });
+  }
+
+  const rates = TranswiftStore.get('tw_rates', null);
+  if (!rates) {
+    TranswiftStore.set('tw_rates', {
+      buyRate: 119.5,
+      sellRate: 118.0,
+      updatedAt: new Date().toLocaleString(),
+      buyTrend: 0.25,
+      sellTrend: -0.1,
+    });
+  }
+
+  const transactions = TranswiftStore.get('tw_transactions', []);
+  if (transactions.length === 0) {
+    TranswiftStore.set('tw_transactions', [
+      {
+        id: 'TW-1001',
+        userEmail: 'user@test.com',
+        type: 'Buy',
+        usdAmount: 250,
+        bdtAmount: 29875,
+        rate: 119.5,
+        status: 'Completed',
+        date: new Date().toLocaleDateString(),
+      },
+      {
+        id: 'TW-1002',
+        userEmail: 'user@test.com',
+        type: 'Sell',
+        usdAmount: 150,
+        bdtAmount: 17700,
+        rate: 118.0,
+        status: 'Pending',
+        date: new Date().toLocaleDateString(),
+      },
+    ]);
+  }
+};
+
+const setupNavigation = () => {
+  const toggle = document.querySelector('.nav-toggle');
+  const links = document.querySelector('.nav-links');
+  if (toggle && links) {
+    toggle.addEventListener('click', () => links.classList.toggle('open'));
+  }
+};
+
+const setupLogout = () => {
+  const logoutBtn = document.getElementById('logoutBtn');
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', () => {
+      localStorage.removeItem('tw_active_user');
+      TranswiftUI.toast('You have been logged out.');
+      window.location.href = 'login.html';
+    });
+  }
+};
+
+const setupContactForm = () => {
+  const form = document.getElementById('contactForm');
+  if (!form) return;
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const name = document.getElementById('contactName').value.trim();
+    const email = document.getElementById('contactEmail').value.trim();
+    const subject = document.getElementById('contactSubject').value.trim();
+    const message = document.getElementById('contactMessage').value.trim();
+
+    if (!name || !email || !subject || !message) {
+      TranswiftUI.toast('Please complete all fields.', 'error');
+      return;
+    }
+
+    const messages = TranswiftStore.get('tw_contacts', []);
+    messages.push({
+      name,
+      email,
+      subject,
+      message,
+      createdAt: new Date().toLocaleString(),
+    });
+    TranswiftStore.set('tw_contacts', messages);
+    form.reset();
+    const success = document.getElementById('contactSuccess');
+    if (success) {
+      success.textContent = 'Message sent! We will get back to you shortly.';
+    }
+    TranswiftUI.toast('Message sent successfully.');
+  });
+};
+
+seedDemoData();
+setupNavigation();
+setupLogout();
+setupContactForm();
+
+window.TranswiftStore = TranswiftStore;
+window.TranswiftUI = TranswiftUI;

--- a/js/orders.js
+++ b/js/orders.js
@@ -3,6 +3,21 @@ const orderSummary = document.getElementById('orderSummary');
 const modal = document.getElementById('orderModal');
 const modalMessage = document.getElementById('modalMessage');
 const closeModal = document.getElementById('closeModal');
+const paymentSelect = document.getElementById('paymentMethod');
+const minOrderEl = document.getElementById('minOrder');
+
+const populateGateways = (gateways) => {
+  if (!paymentSelect) return;
+  const options = ['Select method', ...gateways];
+  paymentSelect.innerHTML = options
+    .map((gateway, index) => {
+      if (index === 0) {
+        return `<option value="">${gateway}</option>`;
+      }
+      return `<option value="${gateway}">${gateway}</option>`;
+    })
+    .join('');
+};
 
 const buildSummary = (type, usdAmount, rate) => {
   const feeRate = 0.015;
@@ -35,8 +50,19 @@ const handleFormSubmit = (event) => {
     return;
   }
 
-  const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+  const rates = TranswiftStore.get('tw_rates', {
+    buyRate: 119.5,
+    sellRate: 118.0,
+    minOrderUsd: 50,
+    gateways: ['Binance', 'Redotpay', 'Payoneer', 'bKash', 'Nagad'],
+  });
   const rate = type === 'Buy' ? rates.buyRate : rates.sellRate;
+  const minOrder = Number(rates.minOrderUsd || 0);
+
+  if (usdAmount < minOrder) {
+    TranswiftUI.toast(`Minimum order is $${minOrder.toFixed(2)}.`, 'error');
+    return;
+  }
   const summary = buildSummary(type, usdAmount, rate);
   const transactions = TranswiftStore.get('tw_transactions', []);
   const user = TranswiftStore.get('tw_active_user', { email: 'guest@transwift.com' });
@@ -68,8 +94,17 @@ const handleFormSubmit = (event) => {
 
 if (orderForm) {
   const rateKey = orderForm.dataset.type === 'Buy' ? 'buyRate' : 'sellRate';
-  const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+  const rates = TranswiftStore.get('tw_rates', {
+    buyRate: 119.5,
+    sellRate: 118.0,
+    minOrderUsd: 50,
+    gateways: ['Binance', 'Redotpay', 'Payoneer', 'bKash', 'Nagad'],
+  });
   const rate = rates[rateKey];
+  populateGateways(rates.gateways || []);
+  if (minOrderEl) {
+    minOrderEl.textContent = Number(rates.minOrderUsd || 0).toFixed(2);
+  }
   const usdInput = document.getElementById('usdAmount');
   usdInput.addEventListener('input', () => {
     const usdAmount = Number(usdInput.value || 0);

--- a/js/orders.js
+++ b/js/orders.js
@@ -1,0 +1,88 @@
+const orderForm = document.querySelector('form[data-type]');
+const orderSummary = document.getElementById('orderSummary');
+const modal = document.getElementById('orderModal');
+const modalMessage = document.getElementById('modalMessage');
+const closeModal = document.getElementById('closeModal');
+
+const buildSummary = (type, usdAmount, rate) => {
+  const feeRate = 0.015;
+  const fee = usdAmount * rate * feeRate;
+  const bdtTotal = usdAmount * rate;
+  const total = bdtTotal + fee;
+  return { fee, bdtTotal, total };
+};
+
+const renderSummary = (type, usdAmount, rate) => {
+  if (!orderSummary) return;
+  const summary = buildSummary(type, usdAmount, rate);
+  orderSummary.innerHTML = `
+    <p>Rate: ${rate.toFixed(2)} BDT/USD</p>
+    <p>BDT Total: ৳${summary.bdtTotal.toFixed(2)}</p>
+    <p>Fees: ৳${summary.fee.toFixed(2)}</p>
+    <p><strong>Payable: ৳${summary.total.toFixed(2)}</strong></p>
+  `;
+};
+
+const handleFormSubmit = (event) => {
+  event.preventDefault();
+  const usdAmount = Number(document.getElementById('usdAmount').value);
+  const paymentMethod = document.getElementById('paymentMethod').value;
+  const accountDetails = document.getElementById('accountDetails').value.trim();
+  const type = orderForm.dataset.type;
+
+  if (!usdAmount || !paymentMethod || !accountDetails) {
+    TranswiftUI.toast('Please complete all fields.', 'error');
+    return;
+  }
+
+  const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+  const rate = type === 'Buy' ? rates.buyRate : rates.sellRate;
+  const summary = buildSummary(type, usdAmount, rate);
+  const transactions = TranswiftStore.get('tw_transactions', []);
+  const user = TranswiftStore.get('tw_active_user', { email: 'guest@transwift.com' });
+
+  const newOrder = {
+    id: `TW-${Math.floor(Math.random() * 9000) + 1000}`,
+    userEmail: user.email,
+    type,
+    usdAmount,
+    bdtAmount: summary.bdtTotal,
+    rate,
+    status: 'Pending',
+    date: new Date().toLocaleDateString(),
+    paymentMethod,
+    accountDetails,
+  };
+
+  transactions.push(newOrder);
+  TranswiftStore.set('tw_transactions', transactions);
+
+  if (modalMessage) {
+    modalMessage.textContent = `Your ${type} order for $${usdAmount.toFixed(2)} has been placed.`;
+  }
+  if (modal) modal.classList.add('active');
+  orderForm.reset();
+  if (orderSummary) orderSummary.innerHTML = '';
+  TranswiftUI.toast('Order placed successfully!');
+};
+
+if (orderForm) {
+  const rateKey = orderForm.dataset.type === 'Buy' ? 'buyRate' : 'sellRate';
+  const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+  const rate = rates[rateKey];
+  const usdInput = document.getElementById('usdAmount');
+  usdInput.addEventListener('input', () => {
+    const usdAmount = Number(usdInput.value || 0);
+    if (usdAmount > 0) {
+      renderSummary(orderForm.dataset.type, usdAmount, rate);
+    } else if (orderSummary) {
+      orderSummary.innerHTML = '';
+    }
+  });
+
+  orderForm.addEventListener('submit', handleFormSubmit);
+}
+
+if (closeModal && modal) {
+  closeModal.addEventListener('click', () => modal.classList.remove('active'));
+}

--- a/js/rates.js
+++ b/js/rates.js
@@ -1,0 +1,57 @@
+const applyRatesToPage = () => {
+  const rates = TranswiftStore.get('tw_rates', {
+    buyRate: 119.5,
+    sellRate: 118.0,
+    updatedAt: new Date().toLocaleString(),
+    buyTrend: 0.25,
+    sellTrend: -0.1,
+  });
+
+  const buyRateEl = document.getElementById('buyRate');
+  const sellRateEl = document.getElementById('sellRate');
+  const updatedEl = document.getElementById('rateUpdated');
+  const buyTrendEl = document.getElementById('buyTrend');
+  const sellTrendEl = document.getElementById('sellTrend');
+
+  if (buyRateEl) buyRateEl.textContent = rates.buyRate.toFixed(2);
+  if (sellRateEl) sellRateEl.textContent = rates.sellRate.toFixed(2);
+  if (updatedEl) updatedEl.textContent = rates.updatedAt;
+
+  if (buyTrendEl) {
+    buyTrendEl.textContent = `${rates.buyTrend > 0 ? '▲' : '▼'} ${Math.abs(rates.buyTrend).toFixed(2)}%`;
+    buyTrendEl.classList.toggle('up', rates.buyTrend >= 0);
+    buyTrendEl.classList.toggle('down', rates.buyTrend < 0);
+  }
+
+  if (sellTrendEl) {
+    sellTrendEl.textContent = `${rates.sellTrend > 0 ? '▲' : '▼'} ${Math.abs(rates.sellTrend).toFixed(2)}%`;
+    sellTrendEl.classList.toggle('up', rates.sellTrend >= 0);
+    sellTrendEl.classList.toggle('down', rates.sellTrend < 0);
+  }
+};
+
+const setupCalculator = () => {
+  const calcBtn = document.getElementById('calcBtn');
+  if (!calcBtn) return;
+  calcBtn.addEventListener('click', () => {
+    const amount = Number(document.getElementById('calcAmount').value);
+    const direction = document.getElementById('calcDirection').value;
+    if (!amount) {
+      TranswiftUI.toast('Enter a valid amount.', 'error');
+      return;
+    }
+
+    const rates = TranswiftStore.get('tw_rates', { buyRate: 119.5, sellRate: 118.0 });
+    let result = 0;
+    if (direction === 'usdToBdt') {
+      result = amount * rates.buyRate;
+      document.getElementById('calcResult').value = `৳${result.toFixed(2)}`;
+    } else {
+      result = amount / rates.sellRate;
+      document.getElementById('calcResult').value = `$${result.toFixed(2)}`;
+    }
+  });
+};
+
+applyRatesToPage();
+setupCalculator();

--- a/js/rates.js
+++ b/js/rates.js
@@ -2,6 +2,8 @@ const applyRatesToPage = () => {
   const rates = TranswiftStore.get('tw_rates', {
     buyRate: 119.5,
     sellRate: 118.0,
+    minOrderUsd: 50,
+    gateways: ['Binance', 'Redotpay', 'Payoneer', 'bKash', 'Nagad'],
     updatedAt: new Date().toLocaleString(),
     buyTrend: 0.25,
     sellTrend: -0.1,
@@ -10,12 +12,14 @@ const applyRatesToPage = () => {
   const buyRateEl = document.getElementById('buyRate');
   const sellRateEl = document.getElementById('sellRate');
   const updatedEl = document.getElementById('rateUpdated');
+  const minOrderEl = document.getElementById('minOrder');
   const buyTrendEl = document.getElementById('buyTrend');
   const sellTrendEl = document.getElementById('sellTrend');
 
   if (buyRateEl) buyRateEl.textContent = rates.buyRate.toFixed(2);
   if (sellRateEl) sellRateEl.textContent = rates.sellRate.toFixed(2);
   if (updatedEl) updatedEl.textContent = rates.updatedAt;
+  if (minOrderEl) minOrderEl.textContent = Number(rates.minOrderUsd || 0).toFixed(2);
 
   if (buyTrendEl) {
     buyTrendEl.textContent = `${rates.buyTrend > 0 ? '▲' : '▼'} ${Math.abs(rates.buyTrend).toFixed(2)}%`;

--- a/js/transactions.js
+++ b/js/transactions.js
@@ -1,0 +1,41 @@
+const tableBody = document.getElementById('transactionTable');
+const filterType = document.getElementById('filterType');
+const searchInput = document.getElementById('searchInput');
+
+const renderTransactions = () => {
+  if (!tableBody) return;
+  const type = filterType ? filterType.value : 'All';
+  const term = searchInput ? searchInput.value.toLowerCase() : '';
+  const transactions = TranswiftStore.get('tw_transactions', []);
+
+  const filtered = transactions.filter((tx) => {
+    const matchesType = type === 'All' || tx.type === type;
+    const searchable = `${tx.status} ${tx.usdAmount} ${tx.bdtAmount}`.toLowerCase();
+    const matchesSearch = !term || searchable.includes(term);
+    return matchesType && matchesSearch;
+  });
+
+  tableBody.innerHTML = filtered
+    .map(
+      (tx) => `
+        <tr>
+          <td>${tx.date}</td>
+          <td>${tx.type}</td>
+          <td>${Number(tx.usdAmount).toFixed(2)}</td>
+          <td>${Number(tx.bdtAmount).toFixed(2)}</td>
+          <td>${Number(tx.rate).toFixed(2)}</td>
+          <td><span class="badge ${tx.status.toLowerCase()}">${tx.status}</span></td>
+        </tr>
+      `
+    )
+    .join('');
+};
+
+if (filterType) {
+  filterType.addEventListener('change', renderTransactions);
+}
+if (searchInput) {
+  searchInput.addEventListener('input', renderTransactions);
+}
+
+renderTransactions();

--- a/login.html
+++ b/login.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login | Transwift</title>
+  <meta name="description" content="Login to your Transwift account to manage USD/BDT exchanges." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/auth.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/auth.js"></script>
+</head>
+<body>
+  <header class="site-header compact">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="register.html" class="btn secondary">Create Account</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="auth-container">
+    <section class="auth-card">
+      <h1>Welcome back</h1>
+      <p class="muted">Access your dashboard to manage USD/BDT trades.</p>
+      <form id="loginForm">
+        <label>Email
+          <input type="email" id="loginEmail" required placeholder="you@email.com" />
+        </label>
+        <label>Password
+          <input type="password" id="loginPassword" required placeholder="••••••••" />
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" id="rememberMe" /> Remember me
+        </label>
+        <button class="btn primary" type="submit">Login</button>
+        <p class="helper">Need an account? <a href="register.html">Register</a></p>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Register | Transwift</title>
+  <meta name="description" content="Create a Transwift account to exchange USD and BDT securely." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/auth.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/auth.js"></script>
+</head>
+<body>
+  <header class="site-header compact">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="login.html" class="btn secondary">Login</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="auth-container">
+    <section class="auth-card">
+      <h1>Create account</h1>
+      <p class="muted">Join Transwift for safe USD/BDT exchanges.</p>
+      <form id="registerForm">
+        <label>Name
+          <input type="text" id="regName" required placeholder="Your name" />
+        </label>
+        <label>Email
+          <input type="email" id="regEmail" required placeholder="you@email.com" />
+        </label>
+        <label>Phone
+          <input type="tel" id="regPhone" required placeholder="+880" />
+        </label>
+        <label>Password
+          <input type="password" id="regPassword" required placeholder="Create password" />
+        </label>
+        <label>Confirm Password
+          <input type="password" id="regConfirm" required placeholder="Confirm password" />
+        </label>
+        <button class="btn primary" type="submit">Register</button>
+        <p class="helper">Already have an account? <a href="login.html">Login</a></p>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/sell.html
+++ b/sell.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sell USD | Transwift</title>
+  <meta name="description" content="Sell USD for BDT instantly with Transwift." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/dashboard.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/rates.js"></script>
+  <script defer src="js/orders.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+      <div class="nav-links">
+        <a href="dashboard.html">Dashboard</a>
+        <a href="buy.html">Buy USD</a>
+        <a href="sell.html" class="active">Sell USD</a>
+        <a href="transactions.html">Transactions</a>
+        <button class="btn ghost" id="logoutBtn">Logout</button>
+      </div>
+    </nav>
+  </header>
+
+  <main class="order-page">
+    <section class="order-summary">
+      <h1>Sell USD</h1>
+      <p>Pay in USD and receive BDT instantly.</p>
+      <div class="card">
+        <p>Current Sell Rate: <strong id="sellRate">118.00</strong> BDT</p>
+        <p>Last updated: <span id="rateUpdated">--</span></p>
+      </div>
+    </section>
+
+    <section class="order-form card">
+      <h2>Place Sell Order</h2>
+      <form id="sellForm" data-type="Sell">
+        <label>USD Amount
+          <input type="number" id="usdAmount" placeholder="100" required />
+        </label>
+        <label>Payment Method
+          <select id="paymentMethod" required>
+            <option value="">Select method</option>
+            <option value="Bank Transfer">Bank Transfer</option>
+            <option value="bKash">bKash</option>
+            <option value="Rocket">Rocket</option>
+          </select>
+        </label>
+        <label>Account Details
+          <input type="text" id="accountDetails" placeholder="Account or wallet number" required />
+        </label>
+        <div class="order-result" id="orderSummary"></div>
+        <button class="btn primary" type="submit">Confirm Sell</button>
+      </form>
+    </section>
+  </main>
+
+  <div class="modal" id="orderModal" aria-hidden="true">
+    <div class="modal-content">
+      <h3>Order Confirmed</h3>
+      <p id="modalMessage"></p>
+      <button class="btn primary" id="closeModal">Done</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/sell.html
+++ b/sell.html
@@ -34,6 +34,7 @@
       <div class="card">
         <p>Current Sell Rate: <strong id="sellRate">118.00</strong> BDT</p>
         <p>Last updated: <span id="rateUpdated">--</span></p>
+        <p class="muted">Minimum order: $<span id="minOrder">--</span></p>
       </div>
     </section>
 
@@ -44,12 +45,7 @@
           <input type="number" id="usdAmount" placeholder="100" required />
         </label>
         <label>Payment Method
-          <select id="paymentMethod" required>
-            <option value="">Select method</option>
-            <option value="Bank Transfer">Bank Transfer</option>
-            <option value="bKash">bKash</option>
-            <option value="Rocket">Rocket</option>
-          </select>
+          <select id="paymentMethod" required></select>
         </label>
         <label>Account Details
           <input type="text" id="accountDetails" placeholder="Account or wallet number" required />

--- a/transactions.html
+++ b/transactions.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Transactions | Transwift</title>
+  <meta name="description" content="Review your USD/BDT transaction history and filter by type or status." />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/dashboard.css" />
+  <script defer src="js/main.js"></script>
+  <script defer src="js/transactions.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar">
+      <a class="logo" href="index.html">Transwift</a>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+      <div class="nav-links">
+        <a href="dashboard.html">Dashboard</a>
+        <a href="buy.html">Buy USD</a>
+        <a href="sell.html">Sell USD</a>
+        <a href="transactions.html" class="active">Transactions</a>
+        <button class="btn ghost" id="logoutBtn">Logout</button>
+      </div>
+    </nav>
+  </header>
+
+  <main class="transactions-page">
+    <section class="section-header">
+      <div>
+        <h1>Transaction History</h1>
+        <p>Track every order with status updates and search tools.</p>
+      </div>
+      <div class="filters">
+        <select id="filterType">
+          <option value="All">All</option>
+          <option value="Buy">Buy</option>
+          <option value="Sell">Sell</option>
+        </select>
+        <input type="search" id="searchInput" placeholder="Search by status or amount" />
+      </div>
+    </section>
+
+    <div class="card">
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Type</th>
+            <th>USD</th>
+            <th>BDT</th>
+            <th>Rate</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody id="transactionTable"></tbody>
+      </table>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Deliver a complete, demo-ready USD↔BDT exchange web app named Transwift with modern UI and local demo data for exploration and testing.
- Provide user and admin flows (registration/login, rate management, buy/sell orders, transaction history) in a static, easily-hosted package.

### Description
- Added full multi-page static site including `index.html`, `login.html`, `register.html`, `dashboard.html`, `buy.html`, `sell.html`, `transactions.html`, `contact.html`, and admin pages under `admin/` for login, dashboard, orders, users, and rates. 
- Implemented styles in `css/style.css`, `css/auth.css`, `css/dashboard.css`, and `css/admin.css` with responsive navigation, card layouts, tables, modals, and toasts following the provided color scheme.
- Implemented client-side logic in `js/` for demo data and storage (`main.js`), authentication (`auth.js`), rate display and calculator (`rates.js`), order placement (`orders.js`), transactions rendering (`transactions.js`), and admin management (`admin.js`) using `localStorage` as a demo backend and seeded demo accounts/rates/transactions.
- Added assets including `assets/images/favicon.svg` and UX touches like order confirmation modals, rate trends, fee calculation, remember-me, search/filter, and admin approve/reject actions.

### Testing
- Started the static server with `python -m http.server 8000` and it served the site successfully. 
- Ran a Playwright script to open `http://127.0.0.1:8000/index.html` and capture a homepage screenshot (artifact: `artifacts/transwift-home.png`), which completed successfully. 
- No unit or integration test suites were added; manual/visual verification was performed via the served site and screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d51bee04832f910359cc18439747)